### PR TITLE
Update AzureLib Version/Common source switch

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,7 @@ repositories {
 dependencies {
     compileOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.5'
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
-    compileOnly "mod.azure.azurelib:azurelib-neo-1.20.1:${azurelib_version}"
+    compileOnly "mod.azure.azurelib:azurelib-core-1.20.1:${azurelib_version}"
     compileOnly "net.tslat.smartbrainlib:SmartBrainLib-neoforge-1.20.1:${project.sbl_version}"
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,7 +23,7 @@ repositories {
 dependencies {
     compileOnly group: 'org.spongepowered', name: 'mixin', version: '0.8.5'
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.1'
-    compileOnly "mod.azure.azurelib:azurelib-core-1.20.1:${azurelib_version}"
+    compileOnly "mod.azure.azurelib:azurelib-common-1.20.1:${azurelib_version}"
     compileOnly "net.tslat.smartbrainlib:SmartBrainLib-neoforge-1.20.1:${project.sbl_version}"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ fabric_loader_version      = 0.14.25
 
 # Libs
 modmenu_version            = 7.2.2
-azurelib_version		   = 2.0.20
+azurelib_version		   = 2.0.21
 sbl_version                = 1.13
 
 # Mod options


### PR DESCRIPTION
This PR does two things: 

- Updates the repo to the latest 1.20.1 release
- Updates the common source to use the newly pushed common version instead of neo. It should fix any weird mapping-related issues that may appear. 

Please don't hesitate to let me know if there are any issues with this!